### PR TITLE
make dvrk_ros be compiled with C++14 standard

### DIFF
--- a/dvrk_robot/CMakeLists.txt
+++ b/dvrk_robot/CMakeLists.txt
@@ -9,7 +9,11 @@
 #
 # --- end cisst license ---
 
-cmake_minimum_required (VERSION 2.8.3)
+cmake_minimum_required (VERSION 3.1)
+
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
 
 project (dvrk_robot)
 


### PR DESCRIPTION
dvrk_ros depends on sawIntuitiveResearchKit module. In order to use C++ 14 features in sawIntuitiveResearchKit. we need to make dvrk_ros be compiled with C++14 standard.