### PR TITLE
Use PoseStamped for set_base_frame

### DIFF
--- a/dvrk_robot/src/dvrk_console.cpp
+++ b/dvrk_robot/src/dvrk_console.cpp
@@ -194,7 +194,7 @@ void dvrk::console::bridge_interface_provided_arm(const std::string & _arm_name,
     // bridged (e.g. subscribers and events)
     const std::string _required_interface_name = _arm_name + "_using_" + _interface_name;
 
-    subscribers_bridge().AddSubscriberToCommandWrite<prmPositionCartesianSet, geometry_msgs::Pose>
+    subscribers_bridge().AddSubscriberToCommandWrite<prmPositionCartesianSet, geometry_msgs::PoseStamped>
         (_required_interface_name, "set_base_frame",
          _arm_name + "/set_base_frame");
     subscribers_bridge().AddSubscriberToCommandWrite<double, std_msgs::Float64>


### PR DESCRIPTION
Use PoseStamped rather than Pose for set_base_frame. Otherwise using set_base_frame results in the robot having a nameless reference frame, which causes tf to reject the base frame transform:
> Error:   TF_NO_FRAME_ID: Ignoring transform with child_frame_id "PSM3"  from authority "/dvrk_1659992630125592185" because frame_id not set